### PR TITLE
Update Node.js version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
           cache: npm
           cache-dependency-path: js-app/package-lock.json


### PR DESCRIPTION
* Updated the `node-version` parameter in the `.github/workflows/publish.yml` workflow from `20` to `24` to use the latest Node.js version.